### PR TITLE
Type List instead of Type Parameters

### DIFF
--- a/example/lib/models.dart
+++ b/example/lib/models.dart
@@ -4,9 +4,13 @@ import 'package:sealed_class/sealed_class.dart';
 
 part 'models.g.dart';
 
-@Sealed()
-abstract class Data<ContainerData, TextData, BoringData, FlutterLogoData>
-    implements $Data {}
+@Sealed([
+  ContainerData,
+  TextData,
+  BoringData,
+  FlutterLogoData,
+])
+abstract class Data implements $Data {}
 
 class ContainerData with $ContainerData implements Data {
   final Color color;

--- a/sealed_class/lib/src/sealed.dart
+++ b/sealed_class/lib/src/sealed.dart
@@ -1,3 +1,5 @@
 class Sealed {
-  const Sealed();
+  final List<Type> types;
+
+  const Sealed(this.types);
 }

--- a/sealed_class_generator/lib/src/gen.dart
+++ b/sealed_class_generator/lib/src/gen.dart
@@ -6,8 +6,8 @@ import 'package:sealed_class/sealed_class.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'checker.dart';
-import 'transformer.dart';
 import 'printer.dart';
+import 'transformer.dart';
 import 'visitor.dart';
 
 class SealedGenerator extends GeneratorForAnnotation<Sealed> {
@@ -17,13 +17,20 @@ class SealedGenerator extends GeneratorForAnnotation<Sealed> {
     ConstantReader annotation,
     BuildStep buildStep,
   ) {
+    final typeParams = annotation.objectValue
+        .getField("types")
+        .toListValue()
+        .map((dartObj) => dartObj.toTypeValue())
+        .map((type) => type.name)
+        .toList();
+
     final visitor = SealedClassVisitor();
     element.visitChildren(visitor);
 
-    Checker.checkInputValidity(visitor.className, visitor.typeParams);
+    Checker.checkInputValidity(visitor.className, typeParams);
 
     final typeParameterData =
-        TypeParameterTransformer.toGeneratedCodeData(visitor.typeParams);
+        TypeParameterTransformer.toGeneratedCodeData(typeParams);
     final printerOutput =
         Printer.constructOutput(visitor.className, typeParameterData);
 

--- a/sealed_class_generator/lib/src/visitor.dart
+++ b/sealed_class_generator/lib/src/visitor.dart
@@ -2,12 +2,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/visitor.dart';
 
 class SealedClassVisitor extends SimpleElementVisitor {
-  final List<String> typeParams = [];
   String className = null;
-
-  @override
-  visitTypeParameterElement(TypeParameterElement element) =>
-      typeParams.add(element.name);
 
   @override
   visitConstructorElement(ConstructorElement element) =>


### PR DESCRIPTION
Use a type list instead of type parameters since that works better with code hinting and is more similar to build_value